### PR TITLE
DRAFT: Extend telemetry

### DIFF
--- a/pts_telemetry/cli.py
+++ b/pts_telemetry/cli.py
@@ -1,6 +1,7 @@
 import sys
 import argparse
 import logging
+import pprint
 
 from pts_telemetry.telemetry import TelemetryConfiguration, Telemetry
 
@@ -34,6 +35,15 @@ def __collect_telemetry():
     telemetry.send_data()
 
 
+def __display_telemetry():
+    configuration = TelemetryConfiguration(auto_load=True)
+    logger.info('Displaying PiRogue telemetry')
+    telemetry = Telemetry(configuration)
+    telemetry.collect_data()
+    # This doesn't use an InfluxDB connection contrary to send_data():
+    pprint.pprint(telemetry.device_info)
+
+
 def main():
     arg_parser = argparse.ArgumentParser(prog='telemetry', description='PiRogue telemetry CLI')
     subparsers = arg_parser.add_subparsers(dest='func')
@@ -44,6 +54,7 @@ def main():
                               choices=['init', 'show', 'disable'])
     # Collection
     subparsers.add_parser('collect', help='Collect and send telemetry data')
+    subparsers.add_parser('display', help='Collect and display telemetry data')
 
     args = arg_parser.parse_args()
     if not args.func:
@@ -72,6 +83,12 @@ def main():
     elif args.func == 'collect':
         try:
             __collect_telemetry()
+        except Exception as e:
+            logger.error(e)
+            sys.exit(1)
+    elif args.func == 'display':
+        try:
+            __display_telemetry()
         except Exception as e:
             logger.error(e)
             sys.exit(1)

--- a/pts_telemetry/telemetry.py
+++ b/pts_telemetry/telemetry.py
@@ -6,6 +6,7 @@ import platform
 import uuid
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from platform import uname_result
 
 import requests
@@ -146,6 +147,14 @@ class Telemetry:
             system_info: uname_result = platform.uname()
             self.device_info['os_type'] = system_info.system.lower()
             self.device_info['os_arch'] = system_info.machine.lower()
+            # base-files is updated during Debian point releases (12.0, 12.1, etc.), which helps get
+            # a sense whether systems are upgraded (with packages flowing from the Debian side).
+            #
+            # Note: On testing, unstable, and apparently on all Ubuntu releases (even stable ones),
+            # we're getting trixie/sid instead (trixie being the codename for the current testing).
+            edv = Path('/etc/debian_version')
+            if edv.exists():
+                self.device_info['os_debian_version'] = edv.read_text().rstrip()
         except Exception:
             self.device_info = {}
             return None


### PR DESCRIPTION
Hi @U039b,

This implements what we talked about a few days ago.

The first commit can be skipped entirely, it was just easier for me to check what I was implementing.

The second commit is a bit cumbersome but there's no standard definition of what a “full release version” looks like. Given we're basing PTS on successive Debian stable releases, I think it's OK to just grab `/etc/debian_version` as it is. Note the `<codename-of-testing>/sid` comments, it's likely that we'll end up with things that don't look like `X.Y` as soon as someone deploys PTS packages on say a `testing` base.

The third commit is a PoC, see comments about whether we want to “define” a `pts_version` based on the `pirogue-base` version. Another way to look at this would be to report a `pirogue-base_version`, paving the way for `pirogue-some-other-important-package_version`, etc.